### PR TITLE
Adding 12 Okta Identity Engine (OIE) API Functions

### DIFF
--- a/Modules/OktaAPI.psm1
+++ b/Modules/OktaAPI.psm1
@@ -367,3 +367,58 @@ function Get-Error($_) {
     ConvertFrom-Json $responseContent
 }
 #endregion
+
+#Authenticator and Captcha manipulation available via OIE API Endpoints. Will not work on an Okta Classic Engine org.
+#region Authenticators: https://developer.okta.com/docs/reference/api/authenticators-admin/
+
+function Get-OktaAuthenticators() {
+    Invoke-Method GET "/api/v1/authenticators"
+}
+
+function Get-OktaAuthenticator($authenticatorId) {
+    Invoke-Method GET "/api/v1/authenticators/$authenticatorId"
+}
+
+function Enable-OktaAuthenticator($authenticatorId) {
+    Invoke-Method POST "/api/v1/authenticators/$authenticatorId/lifecycle/activate"
+}
+
+function Disable-OktaAuthenticator($authenticatorId) {
+    Invoke-Method POST "/api/v1/authenticators/$authenticatorId/lifecycle/deactivate"
+}
+#endregion
+
+#region Captchas: https://developer.okta.com/docs/reference/api/captchas/
+function New-OktaCaptcha($captchaBody) {
+    Invoke-Method POST "/api/v1/captchas" $captchaBody
+}
+
+function Get-OktaCaptcha($captchaId) {
+    Invoke-Method GET "/api/v1/captchas/$captchaId"
+}
+
+function Get-OktaCaptchas() {
+    Invoke-Method GET "/api/v1/captchas"
+}
+
+function Set-OktaCaptcha($captchaId, $captchaBody) {
+    Invoke-Method PUT "/api/v1/captchas/$captchaId" $captchaBody
+}
+
+function Remove-OktaCaptcha($captchaId) {
+    Invoke-Method DELETE "/api/v1/captchas/$captchaId"
+}
+
+#Org-wide Captcha settings control where the end-user is prompted for Captcha: https://developer.okta.com/docs/reference/api/captchas/#org-wide-captcha-settings-operations
+function Get-OktaOrgCaptchaSettings() {
+    Invoke-Method GET "/api/v1/org/captcha"
+}
+
+function Set-OktaOrgCaptchaSettings($orgCaptchaBody) {
+    Invoke-Method PUT "/api/v1/org/captcha" $orgCaptchaBody
+}
+
+function Remove-OktaOrgCaptchaSettings() {
+    Invoke-Method DELETE "/api/v1/org/captcha"
+}
+#endregion

--- a/Modules/OktaAPI.psm1
+++ b/Modules/OktaAPI.psm1
@@ -410,7 +410,7 @@ function Set-OktaCaptchaPartial($captchaId, $captcha) {
 }
 
 function Remove-OktaCaptcha($captchaId) {
-    Invoke-Method DELETE "/api/v1/captchas/$captchaId"
+    $null = Invoke-Method DELETE "/api/v1/captchas/$captchaId"
 }
 
 #Org-wide Captcha settings control where the end-user is prompted for Captcha: https://developer.okta.com/docs/reference/api/captchas/#org-wide-captcha-settings-operations
@@ -423,6 +423,6 @@ function Set-OktaOrgCaptchaSettings($orgCaptcha) {
 }
 
 function Remove-OktaOrgCaptchaSettings() {
-    Invoke-Method DELETE "/api/v1/org/captcha"
+    $null = Invoke-Method DELETE "/api/v1/org/captcha"
 }
 #endregion

--- a/Modules/OktaAPI.psm1
+++ b/Modules/OktaAPI.psm1
@@ -389,8 +389,8 @@ function Disable-OktaAuthenticator($authenticatorId) {
 #endregion
 
 #region Captchas: https://developer.okta.com/docs/reference/api/captchas/
-function New-OktaCaptcha($captchaBody) {
-    Invoke-Method POST "/api/v1/captchas" $captchaBody
+function New-OktaCaptcha($captcha) {
+    Invoke-Method POST "/api/v1/captchas" $captcha
 }
 
 function Get-OktaCaptcha($captchaId) {
@@ -401,8 +401,12 @@ function Get-OktaCaptchas() {
     Invoke-Method GET "/api/v1/captchas"
 }
 
-function Set-OktaCaptcha($captchaId, $captchaBody) {
-    Invoke-Method PUT "/api/v1/captchas/$captchaId" $captchaBody
+function Set-OktaCaptchaFull($captchaId, $captcha) {
+    Invoke-Method PUT "/api/v1/captchas/$captchaId" $captcha
+}
+
+function Set-OktaCaptchaPartial($captchaId, $captcha) {
+    Invoke-Method POST "/api/v1/captchas/$captchaId" $captcha
 }
 
 function Remove-OktaCaptcha($captchaId) {
@@ -414,8 +418,8 @@ function Get-OktaOrgCaptchaSettings() {
     Invoke-Method GET "/api/v1/org/captcha"
 }
 
-function Set-OktaOrgCaptchaSettings($orgCaptchaBody) {
-    Invoke-Method PUT "/api/v1/org/captcha" $orgCaptchaBody
+function Set-OktaOrgCaptchaSettings($orgCaptcha) {
+    Invoke-Method PUT "/api/v1/org/captcha" $orgCaptcha
 }
 
 function Remove-OktaOrgCaptchaSettings() {


### PR DESCRIPTION
Had a code review with Gabriel Sroka to review PowerShell verbs, adding Okta to function definitions, and following API documentation for ID variables. For the 3 endpoints that have body parameters, I followed the definition style from Enable-OktaFactor (https://github.com/gabrielsroka/OktaAPI.psm1/blob/4667b95c3ac051b97b5683e746a3446fbd9f27fd/Modules/OktaAPI.psm1#L124-L126).